### PR TITLE
Debian 12 packer template and some minor fixes

### DIFF
--- a/example_build/deb12k6.json
+++ b/example_build/deb12k6.json
@@ -1,0 +1,83 @@
+{
+    "variables": {
+        "ssh_user": "patient0",
+        "ssh_password": "packer"
+    },
+    "sensitive-variables": ["ssh_password"],
+    "builders": [
+        {
+            "name": "10_generator",
+            "type": "file",
+            "content": "#cloud-config\nssh_pwauth: True\nusers:\n  - name: {{user `ssh_user`}}\n    plain_text_passwd: {{user `ssh_password`}}\n    sudo: ALL=(ALL) NOPASSWD:ALL\n    groups: users, sudo\n    shell: /bin/bash\n    lock_passwd: false\n",
+            "target": "httpdir/user-data"
+        },
+        {
+            "name": "20_builder",
+            "type": "qemu",
+            "iso_url": "https://cdimage.debian.org/cdimage/cloud/bookworm/latest/debian-12-generic-amd64.qcow2",
+            "iso_checksum": "file:https://cdimage.debian.org/cdimage/cloud/bookworm/latest/SHA512SUMS",
+            "disk_image": true,
+            "disk_size": "3G",
+            "disk_compression": true,
+            "format": "qcow2",
+            "headless": "true",
+            "boot_wait": -1,
+            "communicator": "ssh",
+            "ssh_username": "{{user `ssh_user`}}",
+            "ssh_clear_authorized_keys": true,
+            "ssh_password": "{{user `ssh_password`}}",
+            "temporary_key_pair_type": "ed25519",
+            "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S su root -c \"userdel -rf {{user `ssh_user`}}; rm /etc/sudoers.d/90-cloud-init-users; shutdown -P now\"",
+            "output_directory": "output",
+            "vm_name": "deb12k6.qcow2",
+            "qemuargs": [
+                [
+                    "-serial",
+                    "stdio"
+                ],
+                [
+                    "-m",
+                    "512"
+                ],
+                [
+                    "-cdrom",
+                    "cidata.iso"
+                ]
+            ]
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell-local",
+            "inline_shebang": "/bin/bash -xe",
+            "inline": "cd httpdir && genisoimage -output ../cidata.iso -input-charset utf-8 -volid cidata -joliet -r user-data meta-data",
+            "only": [
+                "10_generator"
+            ]
+        },
+        {
+            "script": "scripts/pre-install-baremetal.sh",
+            "type": "shell",
+            "execute_command": "chmod +x {{ .Path }} && sudo {{ .Path }}",
+            "only": [
+                "20_builder"
+            ]
+        },
+        {
+            "only": [
+                "20_builder"
+            ],
+            "type": "file",
+            "source": "files/make_image_bootable.sh",
+            "destination": "/tmp/make_image_bootable.sh"
+        },
+        {
+            "only": [
+                "20_builder"
+            ],
+            "type": "shell",
+            "inline": "sudo -S mkdir /root/.ovh/ && sudo -S mv /tmp/make_image_bootable.sh /root/.ovh/ && sudo -S chmod -R +x /root/.ovh/",
+            "pause_before": "5s"
+        }
+    ]
+}

--- a/example_build/scripts/pre-install-baremetal.sh
+++ b/example_build/scripts/pre-install-baremetal.sh
@@ -18,9 +18,7 @@ sed -i "s/\bmain\b/& contrib non-free/" /etc/apt/sources.list
 
 apt-get update
 
-kernel=$(apt-cache search linux-image-6 | grep -vE 'rt|cloud|unsigned|headers|dbg' | awk '{ print $1 }')
-
-apt-get -y install --no-install-recommends "${kernel}"
+apt-get -y install --no-install-recommends linux-image-amd64
 
 apt-get -y install --no-install-recommends mdadm lvm2 patch btrfs-progs amd64-microcode intel-microcode
 # We will install these in make_image_bootable.sh and only when ZFS is used

--- a/example_build/scripts/pre-install-baremetal.sh
+++ b/example_build/scripts/pre-install-baremetal.sh
@@ -42,7 +42,6 @@ echo "grub-efi-amd64 grub2/update_nvram boolean false" | debconf-set-selections
 
 # Cleanup
 apt-get -y autoremove
-apt-get -y clean
 apt-get -y autoclean
 
 # Disable some cloud-init options:

--- a/example_build/scripts/pre-install-baremetal.sh
+++ b/example_build/scripts/pre-install-baremetal.sh
@@ -12,9 +12,17 @@ apt-get -y purge grub-cloud-amd64
 # grub-pc or grub-efi-amd64's postinst.
 cp /usr/share/grub/default/grub /etc/default/grub
 
+apt-get update
+
 # Add contrib to allow ZFS installation
 # Add non-free-firmware for AMD and Intel microcodes
-sed -i "s/\bmain\b/& contrib non-free/" /etc/apt/sources.list
+apt-get -y install --no-install-recommends lsb-release
+if [ $(lsb_release -rs 2>/dev/null) -ge 12 ];
+then
+	sed -i "s/\bmain\b/& contrib non-free-firmware/" /etc/apt/sources.list.d/debian.sources
+else
+	sed -i "s/\bmain\b/& contrib non-free/" /etc/apt/sources.list
+fi
 
 apt-get update
 


### PR DESCRIPTION
What this PR is about:

- Packer template for Debian 12: Introduced user variables in order to, first, generate httpdir/user-data, then, use the vars in template, and at shutdown, remove the packer user
- Adjust example_build/scripts/pre-install-baremetal.sh
  - For Debian 12 (non-free-firmware)
  - Change the kernel to the distrib default one (to mimic OVH standards apparently)
  - Remove `apt-get clean` which removes downloaded packages

Note to reviewers:
- I used separate commits so that they can be dropped if judged unworthy (default kernel for example)
- Despite the removal of apt-get clean I couldn't make the image work as is on a kimsufi without efi. I didn't have KVM to debug and ended up with installing grub-pc (without download-only) in example_build/scripts/pre-install-baremetal.sh and using `dpkg-reconfigure grub-pc` in example_build/files/make_image_bootable.sh