### PR TITLE
Add sample for building legacy Ubuntu 20.04 image

### DIFF
--- a/example_legacy/files/make_image_bootable.sh
+++ b/example_legacy/files/make_image_bootable.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+######################################################
+# This is an example script that works for Ubuntu 20.04 #
+######################################################
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+# This script will run inside the newly installed system, no need to call chroot
+# The image contains /etc/mdadm/mdadm.conf which was created by mdadm's postinst script.
+# It takes precedence over /etc/mdadm.conf which is generated during partitioning_apply.
+# This means /etc/mdadm.conf will never be read so we can delete it.
+rm -f /etc/mdadm.conf
+# In order to create a prettier config file, we regenerate /etc/mdadm/mdadm.conf
+# with a command similar to that of mdadm's postinst script.
+/usr/share/mdadm/mkconf force-generate
+# Get the right console parameters (including SoL if available) from the rescue's cmdline
+console_parameters="$(grep -Po '\bconsole=\S+' /proc/cmdline | paste -s -d" ")"
+if ! grep '^GRUB_CMDLINE_LINUX="' /etc/default/grub | grep -qF "$console_parameters"; then
+    sed -Ei "s/(^GRUB_CMDLINE_LINUX=.*)\"\$/\1 $console_parameters\"/" /etc/default/grub
+fi
+# Install ZFS packages if required
+if lsblk -lno FSTYPE | grep -qxiF zfs_member; then
+    apt-get -y install --no-install-recommends linux-headers-5.4.0-42-generic zfs-dkms zfsutils-linux
+    # Make sure zpools are imported at boot, this is not required when / is ZFS because the initramfs
+    # imports the pool. However, it is necessary if e.g. /home is ZFS and / is ext4.
+    systemctl enable zfs-import-scan.service
+fi
+if [ -d /sys/firmware/efi ]; then
+    echo "INFO - GRUB will be configured for UEFI boot"
+    apt-get -y install --no-install-recommends grub-efi-amd64
+    # grub-efi-amd64's postinst script does not install GRUB to the EFI partition,
+    # it only updates it:
+    # https://salsa.debian.org/grub-team/grub/-/commit/74eb20a6d7a3
+    # https://salsa.debian.org/grub-team/grub/-/blob/debian/2.04-20/debian/postinst.in#L700
+    # This means we need to install GRUB manually (and we do that after installing grub-efi-amd64
+    # to prevent it from calling grub-install a second time).
+    grub-install --target=x86_64-efi --efi-directory=/boot/efi --no-nvram
+    apt-get -y purge grub-pc-bin
+else
+    echo "INFO - GRUB will be configured for legacy boot"
+    realBootDevicesById=()
+    read -r bootDevice bootDeviceType < <(findmnt -A -c -e -l -n -T /boot/ -o SOURCE,FSTYPE)
+    if [[ "$bootDeviceType" == "zfs" ]]; then
+        bootDevices="$(zpool status -LP "${bootDevice%/*}" | grep -Po '/dev/\S+')"
+    else
+        bootDevices="$bootDevice"
+    fi
+    realBootDevices="$(lsblk -n -p -b -l -o TYPE,NAME "$bootDevices" -s | awk '$1 == "disk" && !seen[$2]++ {print $2}')"
+    # realBootDevices are disks at this point
+    for realBootDevice in $realBootDevices; do
+        # When GRUB is manually installed, grub-pc/install_devices contains values from /dev/disk/by-id.
+        # Each device has two links in that folder, e.g. ata-HGST_HUS726040ALA610_KXXXX and wwn-0x5000cca25defa844.
+        # The postinst script for grub-pc keeps the first link after sorting them, see
+        # https://salsa.debian.org/grub-team/grub/-/blob/debian/2.04-20/debian/postinst.in#L89
+        # Using another link would cause it not to show up in the prompt to reconfigure the package.
+        # shellcheck disable=SC2207
+        realBootDevicesById+=($(find -L /dev/disk/by-id/ -type b -samefile "$realBootDevice" | sort -us | head -n1))
+    done
+    # shellcheck disable=SC2001
+    echo "grub-pc grub-pc/install_devices multiselect $(sed 's/ /, /g' <<<"${realBootDevicesById[@]}")" | debconf-set-selections
+    apt-get -y install --no-install-recommends grub-pc
+    apt-get -y purge grub-efi-amd64-bin
+fi
+apt-get -y autoremove
+apt-get -y clean
+# Generate a new unique machine-id for this server
+systemd-machine-id-setup
+# To update mdadm.conf inside the initramfs (it will be the same as /etc/mdadm/mdadm.conf)
+# Must run after ZFS installation for ZFS modules to be included if necessary
+# and for the initramfs's host id to match that of the real root.
+update-initramfs -u
+# cleanup
+rm -fr /root/.ovh/

--- a/example_legacy/httpdir/meta-data
+++ b/example_legacy/httpdir/meta-data
@@ -1,0 +1,1 @@
+{"instance-id":"001","local-hostname":"ubuntu2004"}

--- a/example_legacy/httpdir/user-data
+++ b/example_legacy/httpdir/user-data
@@ -1,0 +1,9 @@
+#cloud-config
+ssh_pwauth: True
+users:
+  - name: ubuntu
+    plain_text_passwd: changeme!123
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: users, sudo, adm
+    shell: /bin/bash
+    lock_passwd: false

--- a/example_legacy/scripts/pre-install-baremetal.sh
+++ b/example_legacy/scripts/pre-install-baremetal.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+# This forces GRUB to use PARTUUID instead of UUID for root=, which does not
+# work for us, see
+# https://salsa.debian.org/cloud-team/debian-cloud-images/-/merge_requests/388
+rm /etc/default/grub.d/50-cloudimg-settings.cfg
+# Add contrib to allow ZFS installation
+# Add non-free-firmware for AMD and Intel microcodes
+sed -i "s/\bmain\b/& restricted multiverse universe/" /etc/apt/sources.list
+apt-get update
+# Install the 5.4 HWE kernel
+apt-get -y install --no-install-recommends linux-image-5.4.0-42-generic linux-headers-5.4.0-42-generic
+# Hold the kernel packages to prevent updates
+apt-mark hold linux-image-5.4.0-42-generic linux-headers-5.4.0-42-generic linux-image-generic-hwe-20.04 linux-headers-generic-hwe-20.04
+apt-get -y install --no-install-recommends mdadm lvm2 patch btrfs-progs amd64-microcode intel-microcode
+# We will install these in make_image_bootable.sh and only when ZFS is used
+# linux-headers-generic needs to be manually specified because dkms only recommends it
+apt-get -y install --no-install-recommends --download-only linux-headers-5.4.0-42-generic zfs-dkms zfsutils-linux
+apt-get -y dist-upgrade
+# Cleanup
+apt-get -y autoremove
+apt-get -y clean
+# Download GRUB for legacy and UEFI servers, both can't be installed simultaneously.
+apt-get -y install --no-install-recommends --download-only grub-efi-amd64
+apt-get -y install --no-install-recommends --download-only grub-pc
+# Make sure grub-efi-amd64 won't change the boot order.
+echo "grub-efi-amd64 grub2/update_nvram boolean false" | debconf-set-selections
+# Disable some cloud-init options:
+# grub-dpkg sets an incorrect value to "grub-pc/install_devices".
+# growpart and resizefs are not needed and can cause problems with ZFS partitions.
+sed -Ei '/^ - (grub-dpkg|growpart|resizefs)/d' /etc/cloud/cloud.cfg
+# Make ifupdown more verbose to help detect bugs/misconfigurations
+#sed -i 's/^#VERBOSE=.*/VERBOSE=yes/' /etc/default/networking
+
+# Instead of using patch, let's directly modify the grub configuration
+# Backup the original file
+cp /etc/default/grub /etc/default/grub.bak
+
+# Directly modify the GRUB configuration
+cat > /etc/default/grub << 'EOF'
+# This file is based on /usr/share/grub/default/grub, some settings
+# have been changed by OVHcloud.
+
+# If you change this file, run 'update-grub' afterwards to update
+# /boot/grub/grub.cfg.
+# For full documentation of the options in this file, see:
+#   info -f grub -n 'Simple configuration'
+
+GRUB_DEFAULT=0
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
+GRUB_CMDLINE_LINUX_DEFAULT=""
+GRUB_CMDLINE_LINUX="nomodeset iommu=pt"
+GRUB_GFXPAYLOAD_LINUX="text"
+
+# Uncomment to enable BadRAM filtering, modify to suit your needs
+# This works with Linux (no patch required) and with any kernel that obtains
+# the memory map information from GRUB (GNU Mach, kernel of FreeBSD ...)
+#GRUB_BADRAM="0x01234567,0xfefefefe,0x89abcdef,0xefefefef"
+
+# Uncomment to disable graphical terminal (grub-pc only)
+#GRUB_TERMINAL=console
+
+# The resolution used on graphical terminal
+# note that you can use only modes which your graphic card supports via VBE
+# you can see them in real GRUB with the command `vbeinfo'
+#GRUB_GFXMODE=640x480
+
+# Uncomment if you don't want GRUB to pass "root=UUID=xxx" parameter to Linux
+#GRUB_DISABLE_LINUX_UUID=true
+
+# Uncomment to disable generation of recovery mode menu entries
+#GRUB_DISABLE_RECOVERY="true"
+
+# Uncomment to get a beep at grub start
+#GRUB_INIT_TUNE="480 440 1"
+EOF
+
+# Remove old machine-id
+rm -f /etc/machine-id

--- a/example_legacy/ubuntu-20.04-kernel-5.4.json
+++ b/example_legacy/ubuntu-20.04-kernel-5.4.json
@@ -1,0 +1,78 @@
+{
+    "builders": [
+        {
+            "name": "10_generator",
+            "type": "file",
+            "content": "dummy",
+            "target": "dummy_file"
+        },
+        {
+            "name": "20_builder",
+            "type": "qemu",
+            "iso_url": "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img",
+            "iso_checksum": "file:https://cloud-images.ubuntu.com/focal/current/SHA256SUMS",
+            "disk_image": true,
+            "disk_size": "3G",
+            "disk_compression": true,
+            "format": "qcow2",
+            "headless": "true",
+            "boot_wait": -1,
+            "communicator": "ssh",
+            "ssh_username": "devops",
+            "ssh_clear_authorized_keys": true,
+            "ssh_password": "riadvice",
+            "temporary_key_pair_type": "ed25519",
+            "shutdown_command": "echo 'riadvice' | sudo -S shutdown -P now",
+            "output_directory": "output",
+            "vm_name": "ubuntu2004.qcow2",
+            "qemuargs": [
+                [
+                    "-serial",
+                    "stdio"
+                ],
+                [
+                    "-m",
+                    "512"
+                ],
+                [
+                    "-cdrom",
+                    "cidata.iso"
+                ]
+            ]
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell-local",
+            "inline_shebang": "/bin/bash -xe",
+            "inline": "cd httpdir && genisoimage -output ../cidata.iso -input-charset utf-8 -volid cidata -joliet -r user-data meta-data",
+            "only": [
+                "10_generator"
+            ]
+        },
+        {
+            "script": "scripts/pre-install-baremetal.sh",
+            "type": "shell",
+            "execute_command": "chmod +x {{ .Path }} && sudo {{ .Path }}",
+            "only": [
+                "20_builder"
+            ]
+        },
+        {
+            "only": [
+                "20_builder"
+            ],
+            "type": "file",
+            "source": "files/make_image_bootable.sh",
+            "destination": "/tmp/make_image_bootable.sh"
+        },
+        {
+            "only": [
+                "20_builder"
+            ],
+            "type": "shell",
+            "inline": "sudo -S mkdir /root/.ovh/ && sudo -S mv /tmp/make_image_bootable.sh /root/.ovh/ && sudo -S chmod -R +x /root/.ovh/",
+            "pause_before": "5s"
+        }
+    ]
+}


### PR DESCRIPTION
The sample build creates a Ubuntu 20.04 LTS image. The image is working but the distribution is officially out of support.